### PR TITLE
Update the gitops-demo-app

### DIFF
--- a/terraform/main.tfvars
+++ b/terraform/main.tfvars
@@ -1,4 +1,4 @@
 region = "us-central1"
 app_name = "devops-app"
 image_name = "gcr.io/cicdlab-278920/gitops-demo"
-image_tag = "1.1.5"
+image_tag = "1.1.7"


### PR DESCRIPTION
This commit updates the container image to:
    gcr.io/cicdlab-278920/gitops-demo:1.1.7.

Build ID: d5397b81-12f8-449c-ac8e-bc78e4d6ccc6